### PR TITLE
Fix LoadBalancer annotation format

### DIFF
--- a/services/nginx-loadbalancer.yaml
+++ b/services/nginx-loadbalancer.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: nginx
   annotations:
-    loadbalancer.openstack.org/x-forwarded-for: true
+    loadbalancer.openstack.org/x-forwarded-for: "true"
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
Use string type in annotation.

For #1 