### PR TITLE
Added StorageClass for ru-6a

### DIFF
--- a/storageclasses/fast2.ru-6a.yaml
+++ b/storageclasses/fast2.ru-6a.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast2.ru-6a
+provisioner: cinder.csi.openstack.org
+parameters:
+  type: fast2.ru-6a
+  availability: ru-6a
+  fsType: ext4
+allowVolumeExpansion: true


### PR DESCRIPTION
Added a new StorageClass `fast2.ru-6a` as an example for provisioning Cinder volumes in the ru-6a availability zone.
